### PR TITLE
Updated README.md based on Tailwind update to v4

### DIFF
--- a/Web/README.md
+++ b/Web/README.md
@@ -5,7 +5,7 @@
 3. Run the following command in the root of the project to start the tailwind CSS compiler:
 
 ```bash
-npx tailwindcss -i ./input.css -o ./assets/tailwind.css --watch
+npx @tailwindcss/cli -i ./input.css -o ./assets/tailwind.css --watch
 ```
 {% endif %}
 Run the following command in the root of the project to start the Dioxus dev server:


### PR DESCRIPTION
I got this error today;

![image](https://github.com/user-attachments/assets/cd2b5b15-f0ad-46c6-b118-9d83a39ae837)

Apparently it happened due to the recent update of tailwind from v3 to v4, so the previous command doesn't work.

![image](https://github.com/user-attachments/assets/9c51c127-2ebb-4f56-be83-f2b2fc80b4b3)

I updated the README file to reflect this change.